### PR TITLE
Custom storeit value

### DIFF
--- a/src/StoreitValue.js
+++ b/src/StoreitValue.js
@@ -1,4 +1,5 @@
 import { makeEmitter } from "pubit-as-promised";
+import makeValueType from "./makeValueType";
 
 export default class StoreitValue {
     constructor(store, properties) {
@@ -39,6 +40,10 @@ export default class StoreitValue {
             update = { [prop]: value };
         }
         this._store.set(this._key, update);
+    }
+
+    static extend(typeOptions) {
+        return makeValueType(StoreitValue, typeOptions);
     }
 
     _getFromStore() {

--- a/src/makeValueType.js
+++ b/src/makeValueType.js
@@ -1,0 +1,35 @@
+export default function makeValueType(ParentValueType, { store, fields }) {
+    function CustomStoreitValue(properties) {
+        ParentValueType.call(this, store, properties);
+    }
+
+    CustomStoreitValue.prototype = Object.create(ParentValueType.prototype);
+
+    // Expose primary key field as a getter (default is `id`)
+    var { primaryKey } = store.options;
+    Object.defineProperty(CustomStoreitValue.prototype, primaryKey, {
+        get() {
+            return this.key;
+        },
+        enumerable: true
+    });
+
+    fields.forEach((field) => {
+        Object.defineProperty(CustomStoreitValue.prototype, field, {
+            get() {
+                var val;
+                if (this._store.has(this.key)) {
+                    var data = this._store.get(this.key);
+                    val = data[field];
+                }
+                return val;
+            },
+            set(val) {
+                this._store.set(this.key, { [field]: val });
+            },
+            enumerable: true
+        });
+    });
+
+    return CustomStoreitValue;
+}

--- a/test/StoreitValueTest.js
+++ b/test/StoreitValueTest.js
@@ -7,155 +7,189 @@ describe("StoreitValue", function () {
         this.store = new StubStore();
     });
 
-    describe("when creating an instance", () => {
-        beforeEach(() => {
-            this.properties = {
-                id: 1,
-                color: "red",
-                message: "sos"
-            };
-            this.value = new StoreitValue(this.store, this.properties);
-        });
-
-        it("should implement the Storeit interface", () => {
-            this.value.should.respondTo("has");
-            this.value.should.respondTo("get");
-            this.value.should.respondTo("set");
-        });
-
-        it("should implement the Pubit (observable) interface", () => {
-            this.value.should.respondTo("on");
-            this.value.should.respondTo("off");
-            this.value.should.respondTo("once");
-        });
-
-        it("should have expose the store key", () => {
-            this.value.key.should.equal(1);
-        });
-
-        it("should have the key and id be equal", () => {
-            this.value.key.should.equal(this.value.get("id"));
-        });
-
-        it("should set the store with properties", () => {
-            this.store.set.should.have.been.calledWith(this.properties);
-        });
-
-        describe("when getting a property", () => {
+    var testStoreitValueAs = (type, valueAndProperties) => {
+        describe(`when creating an instance from ${type}: `, () => {
             beforeEach(() => {
-                this.color = this.value.get("color");
+                var { value, properties } = valueAndProperties(this.store);
+                this.value = value;
+                this.properties = properties;
             });
 
-            it("should ask the store for the value", () => {
-                this.store.get.should.have.been.calledWith(1);
+            it("should implement the Storeit interface", () => {
+                this.value.should.respondTo("has");
+                this.value.should.respondTo("get");
+                this.value.should.respondTo("set");
             });
 
-            it("should return the right color", () => {
-                this.color.should.equal("red");
+            it("should implement the Pubit (observable) interface", () => {
+                this.value.should.respondTo("on");
+                this.value.should.respondTo("off");
+                this.value.should.respondTo("once");
             });
-        });
 
-        describe("when asking if a value has a property", () => {
-            describe("that exists", () => {
+            it("should have expose the store key", () => {
+                this.value.key.should.equal(this.properties.id);
+            });
+
+            it("should have the key and id be equal", () => {
+                this.value.key.should.equal(this.value.get("id"));
+            });
+
+            it("should set the store with properties", () => {
+                this.store.set.should.have.been.calledWith(this.properties);
+            });
+
+            describe("when getting a property", () => {
                 beforeEach(() => {
-                    this.hasColor = this.value.has("color");
+                    this.color = this.value.get("color");
                 });
 
                 it("should ask the store for the value", () => {
-                    this.store.get.should.have.been.calledWith(1);
+                    this.store.get.should.have.been.calledWith(this.properties.id);
                 });
 
-                it("should return true", () => {
-                    this.hasColor.should.be.true;
+                it("should return the right color", () => {
+                    this.color.should.equal(this.properties.color);
                 });
             });
 
-            describe("that does not exist", () => {
+            describe("when asking if a value has a property", () => {
+                describe("that exists", () => {
+                    beforeEach(() => {
+                        this.hasColor = this.value.has("color");
+                    });
+
+                    it("should ask the store for the value", () => {
+                        this.store.get.should.have.been.calledWith(this.properties.id);
+                    });
+
+                    it("should return true", () => {
+                        this.hasColor.should.be.true;
+                    });
+                });
+
+                describe("that does not exist", () => {
+                    beforeEach(() => {
+                        this.hasFoo = this.value.has("foo");
+                    });
+
+                    it("should ask the store for the value", () => {
+                        this.store.get.should.have.been.calledWith(this.properties.id);
+                    });
+
+                    it("should return false", () => {
+                        this.hasFoo.should.be.false;
+                    });
+                });
+            });
+
+            describe("when setting a property", () => {
                 beforeEach(() => {
-                    this.hasFoo = this.value.has("foo");
+                    this.value.set("color", "blue");
                 });
 
-                it("should ask the store for the value", () => {
-                    this.store.get.should.have.been.calledWith(1);
+                it("should set the store with an object", () => {
+                    this.store.set.getCall(1).should.have.been.calledWith(
+                        this.properties.id,
+                        sinon.match({ color: "blue" })
+                    );
                 });
 
-                it("should return false", () => {
-                    this.hasFoo.should.be.false;
+                it("should return the new color", () => {
+                    this.value.get("color").should.equal("blue");
+                });
+            });
+
+            describe("when setting multiple properties", () => {
+                beforeEach(() => {
+                    this.value.set({ color: "green", message: "success!" });
+                });
+
+                it("should set the store with an object", () => {
+                    this.store.set.getCall(1).should.have.been.calledWith(
+                        this.properties.id,
+                        sinon.match({ color: "green", message: "success!" })
+                    );
+                });
+
+                it("should return the new color", () => {
+                    this.value.get("color").should.equal("green");
+                });
+
+                it("should return the new message", () => {
+                    this.value.get("message").should.equal("success!");
+                });
+            });
+
+            describe("when a listener is attached", () => {
+                beforeEach(() => {
+                    this.changedListener = sinon.stub();
+                    this.value.on("changed", this.changedListener);
+                });
+
+                describe("and a single property is set", () => {
+                    beforeEach(() => {
+                        this.value.set("color", "orange");
+                    });
+
+                    it("should call the listener", () => {
+                        this.changedListener.should.have.been.calledWith(sinon.match({ color: "orange" }));
+                    });
+                });
+
+                describe("and multiple properties are set", () => {
+                    beforeEach(() => {
+                        this.value.set({ color: "black", message: "black is the new orange" });
+                    });
+
+                    it("should call the listener", () => {
+                        this.changedListener.should.have.been.calledWith(sinon.match({
+                            color: "black",
+                            message: "black is the new orange"
+                        }));
+                    });
+                });
+
+                describe("and another value in the store is modified", () => {
+                    beforeEach(() => {
+                        this.store.set({ id: "100", message: "another value" });
+                    });
+
+                    it("should NOT call the listener", () => {
+                        this.changedListener.should.not.have.been.called;
+                    });
                 });
             });
         });
+    };
+    testStoreitValueAs("StoreitValue", (store) => {
+        var properties = {
+            id: "1",
+            color: "red",
+            message: "sos"
+        };
 
-        describe("when setting a property", () => {
-            beforeEach(() => {
-                this.value.set("color", "blue");
-            });
+        return {
+            properties,
+            value: new StoreitValue(store, properties)
+        };
+    });
 
-            it("should set the store with an object", () => {
-                this.store.set.getCall(1).should.have.been.calledWith(1, sinon.match({ color: "blue" }));
-            });
-
-            it("should return the new color", () => {
-                this.value.get("color").should.equal("blue");
-            });
+    testStoreitValueAs("a custom value type", (store) => {
+        var CustomValue = StoreitValue.extend({
+            store,
+            fields: ["color", "message"]
         });
+        var properties = {
+            id: "2",
+            color: "yellow",
+            message: "warning"
+        };
 
-        describe("when setting multiple properties", () => {
-            beforeEach(() => {
-                this.value.set({ color: "green", message: "success!" });
-            });
-
-            it("should set the store with an object", () => {
-                this.store.set.getCall(1).should.have.been.calledWith(1, sinon.match({ color: "green", message: "success!" }));
-            });
-
-            it("should return the new color", () => {
-                this.value.get("color").should.equal("green");
-            });
-
-            it("should return the new message", () => {
-                this.value.get("message").should.equal("success!");
-            });
-        });
-
-        describe("when a listener is attached", () => {
-            beforeEach(() => {
-                this.changedListener = sinon.stub();
-                this.value.on("changed", this.changedListener);
-            });
-
-            describe("and a single property is set", () => {
-                beforeEach(() => {
-                    this.value.set("color", "orange");
-                });
-
-                it("should call the listener", () => {
-                    this.changedListener.should.have.been.calledWith(sinon.match({ color: "orange" }));
-                });
-            });
-
-            describe("and multiple properties are set", () => {
-                beforeEach(() => {
-                    this.value.set({ color: "black", message: "black is the new orange" });
-                });
-
-                it("should call the listener", () => {
-                    this.changedListener.should.have.been.calledWith(sinon.match({
-                        color: "black",
-                        message: "black is the new orange"
-                    }));
-                });
-            });
-
-            describe("and another value in the store is modified", () => {
-                beforeEach(() => {
-                    this.store.set({ id: "2", message: "another value" });
-                });
-
-                it("should NOT call the listener", () => {
-                    this.changedListener.should.not.have.been.called;
-                });
-            });
-        });
+        return {
+            properties,
+            value: new CustomValue(properties)
+        };
     });
 
     describe("when attempting to create an instance w/o a primary key (id)", () => {

--- a/test/StoreitValueTest.js
+++ b/test/StoreitValueTest.js
@@ -1,45 +1,6 @@
 /*jshint expr: true */
-import _ from "underscore";
-import { makeEmitter } from "pubit-as-promised";
 import StoreitValue from "../src/StoreitValue";
-
-function StubStore() {
-    var data = Object.create(null);
-    var publish = makeEmitter(this, ["modified"]);
-
-    data["2"] = { color: "gray", message: "prepopulated" };
-
-    return _.extend(this, {
-        options: {
-            primaryKey: "id"
-        },
-        has: sinon.spy((id) => {
-            return id in data;
-        }),
-        get: sinon.spy((id) => {
-            if (!this.has(id)) {
-                throw new Error("Key does not exist.");
-            }
-            return data[id];
-        }),
-        set: sinon.spy((...args) => {
-            var [id, val] = args;
-
-            if (args.length === 1) {
-                val = id;
-                id = val.id;
-            }
-
-            if (this.has(id)) {
-                _.extend(this.get(id), val);
-            } else {
-                data[id] = val;
-            }
-
-            publish("modified", val, id);
-        })
-    });
-}
+import StubStore from "./support/StubStore";
 
 describe("StoreitValue", function () {
     beforeEach(() => {

--- a/test/makeValueTypeTest.js
+++ b/test/makeValueTypeTest.js
@@ -1,0 +1,79 @@
+/*jshint expr: true */
+import makeValueType from "../src/makeValueType";
+import StoreitValue from "../src/StoreitValue";
+import StubStore from "./support/StubStore";
+
+describe("makeValueType", function () {
+    beforeEach(() => {
+        this.ParentValue = StoreitValue;
+        this.CustomValue = makeValueType(StoreitValue, {
+            store: new StubStore(),
+            fields: ["title", "isDone"]
+        });
+    });
+
+    it("should return a function", () => {
+        (typeof this.CustomValue).should.equal("function");
+    });
+
+    it("should have a prototype that is an instanceof the ParentValue", () => {
+        this.CustomValue.prototype.should.be.an.instanceof(this.ParentValue);
+    });
+
+    describe("when creating an instance of the type", () => {
+        beforeEach(() => {
+            this.value = new this.CustomValue({
+                id: "A",
+                title: "Clean room",
+                isDone: false
+            });
+        });
+
+        describe("when getting properties", () => {
+            it("should return the correct value for each field including primary key", () => {
+                this.value.id.should.equal("A");
+                this.value.title.should.equal("Clean room");
+                this.value.isDone.should.be.false;
+            });
+        });
+
+        describe("when setting", () => {
+            describe("the primary key field", () => {
+                beforeEach(() => {
+                    this.setPrimaryKeyValue = () => {
+                        this.value.id = "HACKED";
+                    };
+                });
+                it("should not allow the primary key field to be modified", () => {
+                    this.setPrimaryKeyValue.should.throw(Error);
+                });
+            });
+
+            describe("a field", () => {
+                beforeEach(() => {
+                    this.value.title = "New title";
+                    this.value.isDone = true;
+                });
+
+                it("should return the new values", () => {
+                    this.value.title.should.equal("New title");
+                    this.value.isDone.should.be.true;
+                });
+            });
+
+            describe("a field and with a listener attached", () => {
+                beforeEach(() => {
+                    this.onChanged = sinon.stub();
+                    this.value.on("changed", this.onChanged);
+                    this.value.isDone = true;
+                });
+
+                it("should call the listener", () => {
+                    this.onChanged.should.have.been.calledWith(
+                        sinon.match({ isDone: true })
+                    );
+                });
+            });
+        });
+    });
+});

--- a/test/support/StubStore.js
+++ b/test/support/StubStore.js
@@ -1,0 +1,40 @@
+import _ from "underscore";
+import { makeEmitter } from "pubit-as-promised";
+
+export default function StubStore() {
+    var data = Object.create(null);
+    var publish = makeEmitter(this, ["modified"]);
+
+    data["100"] = { color: "gray", message: "prepopulated" };
+
+    return _.extend(this, {
+        options: {
+            primaryKey: "id"
+        },
+        has: sinon.spy((id) => {
+            return id in data;
+        }),
+        get: sinon.spy((id) => {
+            if (!this.has(id)) {
+                throw new Error("Key does not exist.");
+            }
+            return data[id];
+        }),
+        set: sinon.spy((...args) => {
+            var [id, val] = args;
+
+            if (args.length === 1) {
+                val = id;
+                id = val.id;
+            }
+
+            if (this.has(id)) {
+                _.extend(this.get(id), val);
+            } else {
+                data[id] = val;
+            }
+
+            publish("modified", val, id);
+        })
+    });
+}


### PR DESCRIPTION
You can now do this.

``` javascript
var NoteValue = StoreitValue.extends({
    store: noteStore,
    fields: ["color", "text", "path"]
});

// Then somewhere far far away
var note = new NoteValue({ id: "123456", text: "I'm a note!", path: "c/f/i" });

console.log(note.path);
console.log(note.text);
note.text = "Nice work"; // Saves directly into the store.

note.on("changed", (updates) => console.log(updates));
```
