### PR TITLE
Allow get when prop does not exist.

### DIFF
--- a/src/StoreitValue.js
+++ b/src/StoreitValue.js
@@ -32,12 +32,12 @@ export default class StoreitValue {
 
     has(prop) {
         var value = this._getFromStore();
-        return prop in value;
+        return value && prop in value;
     }
 
     get(prop) {
         var value = this._getFromStore();
-        return value[prop];
+        return value && value[prop];
     }
 
     set(...args) {
@@ -56,7 +56,7 @@ export default class StoreitValue {
     }
 
     _getFromStore() {
-        return this._store.get(this._key);
+        return this._store.has(this._key) && this._store.get(this._key);
     }
 
     _publishChangedIfValueModified(value, key) {

--- a/test/StoreitValueTest.js
+++ b/test/StoreitValueTest.js
@@ -48,16 +48,28 @@ describe("StoreitValue", function () {
             });
 
             describe("when getting a property", () => {
-                beforeEach(() => {
-                    this.color = this.value.get("color");
+                describe("that exists", () => {
+                    beforeEach(() => {
+                        this.color = this.value.get("color");
+                    });
+
+                    it("should ask the store for the value", () => {
+                        this.store.get.should.have.been.calledWith(this.properties.id);
+                    });
+
+                    it("should return the right color", () => {
+                        this.color.should.equal(this.properties.color);
+                    });
                 });
 
-                it("should ask the store for the value", () => {
-                    this.store.get.should.have.been.calledWith(this.properties.id);
-                });
+                describe("that does not exist", () => {
+                    beforeEach(() => {
+                        this.nothing = this.value.get("nothing");
+                    });
 
-                it("should return the right color", () => {
-                    this.color.should.equal(this.properties.color);
+                    it("should return undefined", () => {
+                        global.expect(this.nothing).to.be.undefined;
+                    });
                 });
             });
 


### PR DESCRIPTION
Should behave just like any other object and return undefined.
