### PR TITLE
Add `toObject` and `isStored`.

### DIFF
--- a/src/StoreitValue.js
+++ b/src/StoreitValue.js
@@ -11,6 +11,7 @@ export default class StoreitValue {
             throw new Error("StoreitValue creation failed! Missing primary key in properties.");
         }
 
+        this._primaryKeyName = primaryKey;
         this._key = properties[primaryKey];
 
         // Populate store with values if provided.
@@ -28,6 +29,10 @@ export default class StoreitValue {
 
     get key() {
         return this._key;
+    }
+
+    get isStored() {
+        return this._store.has(this._key);
     }
 
     has(prop) {
@@ -51,12 +56,16 @@ export default class StoreitValue {
         this._store.set(this._key, update);
     }
 
+    toObject() {
+        return this.isStored ? this._getFromStore() : { [this._primaryKeyName]: this.key };
+    }
+
     static extend(typeOptions) {
         return makeValueType(StoreitValue, typeOptions);
     }
 
     _getFromStore() {
-        return this._store.has(this._key) && this._store.get(this._key);
+        return this.isStored ? this._store.get(this._key) : undefined;
     }
 
     _publishChangedIfValueModified(value, key) {

--- a/test/StoreitValueTest.js
+++ b/test/StoreitValueTest.js
@@ -19,6 +19,8 @@ describe("StoreitValue", function () {
                 this.value.should.respondTo("has");
                 this.value.should.respondTo("get");
                 this.value.should.respondTo("set");
+                this.value.should.respondTo("toObject");
+                this.value.should.have.property("isStored");
             });
 
             it("should implement the Pubit (observable) interface", () => {
@@ -37,6 +39,14 @@ describe("StoreitValue", function () {
 
             it("should set the store with properties", () => {
                 this.store.set.should.have.been.calledWith(this.properties);
+            });
+
+            it("should report being stored", () => {
+                this.value.isStored.should.be.true;
+            });
+
+            it("should convert to a plain vanilla object", () => {
+                this.value.toObject().should.eql(this.properties);
             });
 
             it("should listen to the store for modified events", () => {
@@ -238,6 +248,14 @@ describe("StoreitValue", function () {
 
         it("should not set the store", () => {
             this.store.set.should.not.have.been.called;
+        });
+
+        it("should not be stored", () => {
+            this.value.isStored.should.be.false;
+        })
+
+        it("should convert to an object w/ just isStored", () => {
+            this.value.toObject().should.eql({ id: "ABC" });
         });
 
         it("should listen to the store for modified events", () => {


### PR DESCRIPTION
Allow clients to convert store value to a plain vanilla object.
Also query if the value is in the store.
